### PR TITLE
feat: Add base href and .nojekyll file

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <base href="/oct-testbed/">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Open-Source Consciousness Testbed (OCT)</title>


### PR DESCRIPTION
This commit introduces two changes for GitHub Pages deployment:

1. Inserts a `<base href="/oct-testbed/">` tag into `index.html` immediately after the opening `<head>` tag. This ensures that all relative resource paths resolve correctly when the site is served from a subdirectory.

2. Adds an empty `.nojekyll` file to the repository root. This file signals to GitHub Pages to disable the Jekyll static site generator, allowing the site to be published as-is.