### PR TITLE
feat: Implement provider abstraction and API key management

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,23 @@
             </div>
           </div>
 
+          <div class="mt-4 border-t border-border-color pt-4">
+            <h3 class="panel-title text-base mb-3">Interpretation Settings</h3>
+            <div class="space-y-3 text-sm">
+              <div class="flex items-center justify-between gap-3">
+                <label for="provider-select" class="metric-label flex-shrink-0">Provider</label>
+                <select id="provider-select" class="w-full bg-bg-primary border border-border-color rounded-md px-2 py-1">
+                  <!-- Options will be populated by app.js -->
+                </select>
+              </div>
+              <div class="flex items-center justify-between gap-3">
+                <label for="api-key-input" class="metric-label flex-shrink-0">API Key</label>
+                <input type="password" id="api-key-input" class="w-full bg-bg-primary border border-border-color rounded-md px-2 py-1" placeholder="Enter your API key">
+                <button id="save-key-btn" class="btn bg-blue-600 hover:bg-blue-500 text-xs px-3 py-1">Save</button>
+              </div>
+            </div>
+          </div>
+
           <div class="mt-4 border-t border-border-color pt-4 text-sm">
              <div class="flex items-center justify-center gap-3">
                <label for="gemini-toggle" class="metric-label">Use Online Interpretation</label>
@@ -231,6 +248,7 @@
     </main>
   </div>
 
+  <script src="js/providers.js"></script>
   <script src="app.js"></script>
 <script>window.parent.postMessage({ action: "ready" }, "*"); 
  

--- a/js/providers.js
+++ b/js/providers.js
@@ -1,0 +1,22 @@
+const llm_providers = {
+  "Gemini": {
+    interpret: async function(prompt, apiKey) {
+      const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
+      const payload = { contents: [{ role: "user", parts: [{ text: prompt }] }] };
+
+      const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
+      const result = await response.json();
+      const text = result?.candidates?.[0]?.content?.parts?.[0]?.text;
+      return text || 'Could not generate an interpretation. The model returned an empty response.';
+    }
+  }
+  // Future providers can be added here
+};


### PR DESCRIPTION
This commit introduces a provider abstraction for handling different LLMs and adds a new UI for managing API keys.

- Creates a `js/providers.js` file to house the logic for different LLM providers, starting with Gemini.
- Refactors `app.js` to use the new provider abstraction, removing the hardcoded fetch call from `interpretSystemState`.
- Adds a new "Interpretation Settings" section to `index.html` with a dropdown to select the provider, an input for the API key, and a save button.
- Implements the logic in `app.js` to manage the new UI, including populating the dropdown, saving/loading API keys from `localStorage`, and enabling/disabling the online interpretation toggle based on key availability.